### PR TITLE
Feat/death system

### DIFF
--- a/Scenes/DebugScene.tscn
+++ b/Scenes/DebugScene.tscn
@@ -1,7 +1,26 @@
-[gd_scene load_steps=2 format=3 uid="uid://d0tlmn6h3m2pv"]
+[gd_scene load_steps=4 format=3 uid="uid://d0tlmn6h3m2pv"]
 
 [ext_resource type="PackedScene" uid="uid://d08mh10yj57o" path="res://Scenes/Player.tscn" id="1_1oq38"]
+[ext_resource type="PackedScene" uid="uid://h3hj2gcjp86h" path="res://Scenes/Components/HealthComponent/HealthBar.tscn" id="1_bees8"]
+[ext_resource type="PackedScene" uid="uid://coq4ou30uv4fn" path="res://Scenes/Components/HealthComponent/HealthComponent.tscn" id="3_r4mrc"]
 
 [node name="DebugScene" type="Node2D"]
 
-[node name="Player" parent="." instance=ExtResource("1_1oq38")]
+[node name="HealthBar" parent="." instance=ExtResource("1_bees8")]
+anchors_preset = 0
+anchor_right = 0.0
+anchor_bottom = 0.0
+offset_left = 30.0
+offset_top = 30.0
+offset_right = 330.0
+offset_bottom = 57.0
+grow_horizontal = 1
+grow_vertical = 1
+
+[node name="Player" parent="." node_paths=PackedStringArray("_health", "_healthBar") instance=ExtResource("1_1oq38")]
+_health = NodePath("HealthComponent")
+_healthBar = NodePath("../HealthBar")
+
+[node name="HealthComponent" parent="Player" instance=ExtResource("3_r4mrc")]
+_health = 42
+_isDead = false

--- a/Scripts/Components/HealthComponent/HealthComponent.cs
+++ b/Scripts/Components/HealthComponent/HealthComponent.cs
@@ -3,21 +3,34 @@ using Godot;
 
 public partial class HealthComponent : Node
 {
-	[Signal]
-	public delegate void HealthChangedEventHandler(int newValue);
+	[Signal] public delegate void HealthChangedEventHandler(int newValue);
+	[Signal] public delegate void DeathStatusChangedEventHandler(bool isDead);
 
-	[Export]
-	public int maxHealth = 100;
-	
-	[Export]
-	private int _health = 0;
+	[Export] public int maxHealth = 100;	
+	[Export] private int _health = 0;
 	public int Health
 	{
 		get => _health;
-		set 
+		private set
 		{
 			_health = Math.Clamp(value, 0, maxHealth);
+			if (0 >= Health) {
+				IsDead = true;
+			}
+			if (0 < Health && IsDead) {
+				IsDead = false;
+			}
 			EmitSignal(SignalName.HealthChanged, _health);
+		}
+	}
+	[Export] private bool _isDead = true;
+	public bool IsDead
+	{
+		get => _isDead;
+		private set
+		{
+			_isDead = value;
+			EmitSignal(SignalName.DeathStatusChanged, _isDead);
 		}
 	}
 
@@ -25,17 +38,23 @@ public partial class HealthComponent : Node
 	{
 		Health -= value;
 	}
-
 	public void Heal(int value)
 	{
 		Health += value;
+	}
+	public void Kill()
+	{
+		Health = 0;
 	}
 
 	public override void _UnhandledInput(InputEvent @event)
 	{
 		if (@event.IsActionPressed("DebugKey")) {
-			GD.Print("[DEBUG KEY]: Healing player of 10 HP");
+			GD.Print("[DEBUG KEY]: Healing of 10 HP");
 			Heal(10);
+		} else if (@event.IsActionPressed("SecondDebugKey")) {
+			GD.Print("[SECOND DEBUG KEY]: Killing");
+			Kill();
 		}
 	}
 }

--- a/Scripts/PlayerController.cs
+++ b/Scripts/PlayerController.cs
@@ -4,16 +4,22 @@ using System;
 public partial class PlayerController : CharacterBody2D
 {
 	
-	//Exportables stats here
+	//Exportables stats her
 	[Export] private float _baseSpeed = 500f;
 	//Exportables object here(managers/handlers...)
 	[Export]private ShootManager _shootManager;
+
+	[ExportGroup("Health Component")]
+	[Export] private HealthComponent _health;
+	[Export] private UI_HealthComponent _healthBar;
+
 	//Non exportables here
 	
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready()
 	{
-		
+		_health.DeathStatusChanged += OnDeathStatusChangedSignal;
+		_healthBar.Connect(_health);
 	}
 
 	// Called every frame. 'delta' is the elapsed time since the previous frame.
@@ -28,6 +34,13 @@ public partial class PlayerController : CharacterBody2D
 		Velocity = move_input * _baseSpeed;
 
 		MoveAndSlide();
+	}
+
+	private void OnDeathStatusChangedSignal(bool isDead)
+	{
+		if (isDead) GD.Print("Player Character died.");
+		else GD.Print("Player Character is back in the land of the living. Stay determined !");
+		
 	}
 
 	//Things that are not continuous(i.e input where the player does not hold the key down)

--- a/project.godot
+++ b/project.godot
@@ -50,3 +50,13 @@ Fire1={
 "events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)
 ]
 }
+DebugKey={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":true,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":81,"key_label":0,"unicode":65,"location":0,"echo":false,"script":null)
+]
+}
+SecondDebugKey={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":true,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":69,"key_label":0,"unicode":101,"location":0,"echo":false,"script":null)
+]
+}


### PR DESCRIPTION
### Death System
Add death system to the health component:
- Every entity with an health component can now die, and bring back to life.

---

### Playground
An example of how the health component and death system works as been added to DebugScene.
- Shift+A to heal the player character.
- Shift+E to kill the player character.

---

### Debug Keys
Debug Keys has been added for testing purposes
- DebugKey = Shift+A(Q in QWERTY)
- SecondDebugKey = Shift+E